### PR TITLE
Develop

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -133,20 +133,6 @@
                                 <input class="form-check-input" type="checkbox" value="" id="placed-visible" checked>
                                 <label class="form-check-label" for="placed-visible">
                                     Placed map elements
-                                    <a id="remove-all-elements" href="javascript:" title="Remove all map elements">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor"
-                                             class="bi bi-trash3-fill" viewBox="0 0 16 16">
-                                            <path d="M11 1.5v1h3.5a.5.5 0 0 1 0 1h-.538l-.853 10.66A2 2 0 0 1 11.115 16h-6.23a2 2 0 0 1-1.994-1.84L2.038 3.5H1.5a.5.5 0 0 1 0-1H5v-1A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5Zm-5 0v1h4v-1a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5ZM4.5 5.029l.5 8.5a.5.5 0 1 0 .998-.06l-.5-8.5a.5.5 0 1 0-.998.06Zm6.53-.528a.5.5 0 0 0-.528.47l-.5 8.5a.5.5 0 0 0 .998.058l.5-8.5a.5.5 0 0 0-.47-.528ZM8 4.5a.5.5 0 0 0-.5.5v8.5a.5.5 0 0 0 1 0V5a.5.5 0 0 0-.5-.5Z"/>
-                                        </svg>
-                                    </a>
-                                    <a id="undo-last-element" href="javascript:" title="Remove most recent map element">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor"
-                                             class="bi bi-caret-left-fill" viewBox="0 0 16 16">
-                                            <path d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
-                                        </svg>
-                                    </a>
                                 </label>
                                 <p style="margin-bottom: 0">
                                     <small class="text-muted">Double click or right click on map</small>
@@ -344,27 +330,9 @@
                                     </label>
                                 </div>
                                 <div style="margin: 5px 0">
-                                    <div class="btn-group" role="group" aria-label="Basic example">
-                                        <button id="drawing-mode" type="button" class="btn btn-secondary">Start drawing
-                                            mode
-                                        </button>
-                                        <button id="clear-paths" type="button" class="btn btn-link"
-                                                title="Clear all drawings">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                                 fill="currentColor"
-                                                 class="bi bi-trash3-fill" viewBox="0 0 16 16">
-                                                <path d="M11 1.5v1h3.5a.5.5 0 0 1 0 1h-.538l-.853 10.66A2 2 0 0 1 11.115 16h-6.23a2 2 0 0 1-1.994-1.84L2.038 3.5H1.5a.5.5 0 0 1 0-1H5v-1A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5Zm-5 0v1h4v-1a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5ZM4.5 5.029l.5 8.5a.5.5 0 1 0 .998-.06l-.5-8.5a.5.5 0 1 0-.998.06Zm6.53-.528a.5.5 0 0 0-.528.47l-.5 8.5a.5.5 0 0 0 .998.058l.5-8.5a.5.5 0 0 0-.47-.528ZM8 4.5a.5.5 0 0 0-.5.5v8.5a.5.5 0 0 0 1 0V5a.5.5 0 0 0-.5-.5Z"/>
-                                            </svg>
-                                        </button>
-                                        <button id="undo-path" type="button" class="btn btn-link"
-                                                title="Undo last drawing">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                                 fill="currentColor"
-                                                 class="bi bi-caret-left-fill" viewBox="0 0 16 16">
-                                                <path d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
-                                            </svg>
-                                        </button>
-                                    </div>
+                                    <button id="drawing-mode" type="button" class="btn btn-secondary">Start drawing
+                                        mode
+                                    </button>
                                 </div>
                                 <small class="text-muted">
                                     Shift+D to toggle drawing mode on the fly
@@ -439,6 +407,69 @@
         </div>
 
         <div id="canvas-panel" class="col col-lg-6 mb-3 ">
+            <input hidden id="title" type="text" value="Untitled" style="border: none; background-color: transparent; color: white; font-size: 22px; width: 100%; margin-bottom: 5px;" readonly>
+            <div id="tools-panel" class="row editor-only" style="margin-bottom: 8px;">
+                <style>
+                    .w-auto {
+                        width: auto;
+                        padding: 2px 6px;
+                    }
+                    .tool {
+                        cursor: pointer;
+                        width: auto;
+                        color: orange;
+                        padding: 2px 6px;
+                        border: 2px solid transparent;
+                    }
+                    .tool.selected {
+                        border: 2px dotted white;
+                        border-radius: 25px;
+                    }
+                </style>
+                <div class="col col-auto">
+                    <span style="font-size: 18px">Tools</span>
+                </div>
+                <div class="col col-auto">
+                    <div class="row">
+                        <span id="tool-drag" class="tool selected" title="Navigate & Select (Shift+W)">
+                            <i class="bi bi-hand-index-thumb"></i>
+                        </span>
+                        <span id="tool-draw" class="tool" title="Free Draw (Shift+D)">
+                            <i class="bi bi-brush"></i>
+                        </span>
+                        <span id="tool-erase" class="tool" title="Eraser (Shift+E)">
+                            <i class="bi bi-eraser"></i>
+                        </span>
+                    </div>
+                </div>
+                <div class="col col-auto">
+                    <span style="font-size: 18px">Dbl-Click</span>
+                </div>
+                <div class="col col-auto">
+                    <div class="row">
+                        <select id="dbl-click-element" class="form-select form-select-sm">
+                        </select>
+                    </div>
+                </div>
+                <div class="col col-auto">
+                    <span style="font-size: 18px">Elements</span>
+                </div>
+                <div class="col col-auto">
+                    <div class="row">
+                        <span class="w-auto"><a id="remove-all-elements" href="javascript:">Clear</a></span>
+                        <span class="w-auto"><a id="undo-last-element" href="javascript:">Remove last</a></span>
+                    </div>
+                </div>
+                <div class="col col-auto">
+                    <span style="font-size: 18px">Drawings</span>
+                </div>
+                <div class="col col-auto">
+                    <div class="row">
+                        <span class="w-auto"><a id="clear-paths"href="javascript:">Clear</a></span>
+                        <span class="w-auto"><a id="undo-path" href="javascript:">Remove last</a></span>
+                    </div>
+                </div>
+            </div>
             <div id="canvas-container">
                 <canvas id="canvas" class="hasmenu drag-mode"></canvas>
             </div>
@@ -725,22 +756,22 @@
                                         }
                                     </script>
                                     <span class="color blue" title="Blue" style="color: #ffffff"
-                                          onclick="setColorsAndOpacity('#0080ff', 0.35, '#ffffff')">T</span>
+                                          onclick="setColorsAndOpacity('#0080ff', 0.5, '#ffffff')">T</span>
                                     <span class="color red" title="Red" style="color: #ffffff"
-                                          onclick="setColorsAndOpacity('#ff8080', 0.35, '#ffffff')">T</span>
+                                          onclick="setColorsAndOpacity('#ff8080', 0.5, '#ffffff')">T</span>
 
                                     <span class="color" style="background-color:#ff8000; color: #000000" title="Orange"
-                                          onclick="setColorsAndOpacity('#ff8000', 0.35, '#000000')">T</span>
+                                          onclick="setColorsAndOpacity('#ff8000', 0.5, '#000000')">T</span>
                                     <span class="color" style="background-color:#ffff80; color: #000000" title="Yellow"
-                                          onclick="setColorsAndOpacity('#ffff80', 0.35, '#000000')">T</span>
+                                          onclick="setColorsAndOpacity('#ffff80', 0.5, '#000000')">T</span>
                                     <span class="color" style="background-color:#00ff00; color: #000000" title="Green"
-                                          onclick="setColorsAndOpacity('#00ff00', 0.35, '#000000')">T</span>
+                                          onclick="setColorsAndOpacity('#00ff00', 0.5, '#000000')">T</span>
                                     <span class="color" style="background-color:#8000ff; color: #ffffff" title="Purple"
-                                          onclick="setColorsAndOpacity('#8000ff', 0.35, '#ffffff')">T</span>
+                                          onclick="setColorsAndOpacity('#8000ff', 0.5, '#ffffff')">T</span>
                                     <span class="color" style="background-color:#ffffff; color: #000000" title="White"
-                                          onclick="setColorsAndOpacity('#ffffff', 0.55, '#000000')">T</span>
+                                          onclick="setColorsAndOpacity('#ffffff', 0.5, '#000000')">T</span>
                                     <span class="color" style="background-color:#c0c0c0; color: #000000" title="Gray"
-                                          onclick="setColorsAndOpacity('#c0c0c0', 0.55, '#000000')">T</span>
+                                          onclick="setColorsAndOpacity('#c0c0c0', 0.5, '#000000')">T</span>
                                 </div>
                                 <br>
                                 <div id="text-color-div" class="text" style="display: none">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -463,7 +463,7 @@
                                         onclick="document.getElementById('importFileChooser').click()">
                                     <span class="spinner"><span class="spinner-border spinner-border-sm" role="status"></span></span>
                                     <i class="bi bi-upload"></i>&nbsp;&nbsp;Import
-                                    <input id="importFileChooser" type="file" hidden/>
+                                    <input id="importFileChooser" type="file" accept="zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed" hidden/>
                                 </button>
                                 <button id="export" class="btn btn-secondary">
                                     <span class="spinner"><span class="spinner-border spinner-border-sm" role="status"></span></span>

--- a/script.js
+++ b/script.js
@@ -1747,11 +1747,7 @@ const mll = (function () {
             }
 
             function getSelectedSlide() {
-                for (let i = 0; i < slides.length; i++) {
-                    if (selectedSlide === slides[i].id) {
-                        return slides[i];
-                    }
-                }
+                return getSlide(selectedSlide);
             }
 
             new ClipboardJS('.btn');

--- a/script.js
+++ b/script.js
@@ -395,6 +395,9 @@ const mll = (function () {
                     addMapElement(meta.originalEvent, meta.type, meta.modifier, false, meta.id, elementState[i]);
                 }
             }
+
+            changeZIndexBySize();
+            fixElementSelectBoxes();
         }
 
         if (controlState || elementState) {
@@ -1263,7 +1266,7 @@ const mll = (function () {
                 left: e.absolutePointer.x,
                 width: 380,
                 height: 380,
-                opacity: 0.35,
+                opacity: 0.5,
                 fill: "#0080FFFF",
                 zIndex: 10,
                 hasBorders: false,
@@ -1325,7 +1328,7 @@ const mll = (function () {
                 originX: "center",
                 originY: "center",
                 //centeredScaling: true,
-                opacity: 0.35,
+                opacity: 0.5,
                 fill: "#0080FFFF",
                 zIndex: 10,
                 hasBorders: false,
@@ -1526,8 +1529,49 @@ const mll = (function () {
         order();
     }
 
+    function deleteObject(eventData, transform) {
+        const target = transform.target;
+
+        let removedElement = false;
+        let removedDrawing = false;
+        for (let i = 0; i < placed.length; i++) {
+            if (placed[i].type.id === target.type.id) {
+                placed.splice(i, 1);
+                removedElement = true;
+                break;
+            }
+        }
+        for (let i = 0; i < drawings.length; i++) {
+            if (drawings[i].type.id === target.type.id) {
+                drawings.splice(i, 1);
+                removedDrawing = true;
+                break;
+            }
+        }
+
+        controls.fabricCanvas.remove(target);
+        controls.exportCanvas.remove(target);
+        if (target.type && target.type.also) {
+            const also = target.type.also;
+            for (let j = 0; j < also.length; j++) {
+                controls.fabricCanvas.remove(also[j]);
+                controls.exportCanvas.remove(also[j]);
+            }
+        }
+        controls.fabricCanvas.requestRenderAll();
+
+        if (removedElement) {
+            roomEditorUpdateElements();
+        }
+        if (removedDrawing) {
+            roomEditorUpdateDrawings();
+        }
+    }
+
     const internal = {
         init: function () {
+            controls.inputTitle = $("#title");
+
             controls.comboMapSelect = $("#map-select");
             controls.checkGrid = $("#grid-visible");
             controls.checkArty = $("#arty-visible");
@@ -1617,6 +1661,19 @@ const mll = (function () {
             controls.slidesManageModal = $("#slidesManageModal");
             controls.submitUpdateSlides = $("#updateSlides");
             elements.manageSlidesDiv = $("#manage-slides-list");
+
+            $('html').on('click', function (e) {
+                if (!$(e.target).is('#title')) {
+                    controls.inputTitle.attr('readonly', true);
+                } else {
+                    controls.inputTitle.attr('readonly', false);
+                }
+            });
+            controls.inputTitle.on('keypress', function (e) {
+                if (e.key === "Enter") {
+                    controls.inputTitle.attr('readonly', true);
+                }
+            });
 
             controls.manageConfigs.click(function () {
                 elements.manageSlidesDiv.html("");
@@ -2042,7 +2099,10 @@ const mll = (function () {
                 scale: 1,
                 moveCursor: 'default',
                 hoverCursor: 'default',
-                viewportTransform: [0.40, 0, 0, 0.40, 0, 0]
+                viewportTransform: [0.40, 0, 0, 0.40, 0, 0],
+                isDragMode: true,
+                isDrawingMode: false,
+                isEraserMode: false
             });
             controls.fabricCanvas.setHeight(800);
             controls.fabricCanvas.setBackgroundColor({
@@ -2406,7 +2466,7 @@ const mll = (function () {
                             customizable: "shape",
                             saveKeepScale: true,
                         },
-                        opacity: 0.35,
+                        opacity: 0.5,
                         fill: "#0080FFFF",
                         perPixelTargetFind: true,
                         zIndex: 10,
@@ -2417,7 +2477,15 @@ const mll = (function () {
                         originY: "center",
                     });
                     polygon.setControlsVisibility({
-                        mt: false, mb: false, ml: false, mr: false, bl: false, br: false, tl: false, tr: false, mtr: true,
+                        mt: false,
+                        mb: false,
+                        ml: false,
+                        mr: false,
+                        bl: false,
+                        br: false,
+                        tl: false,
+                        tr: false,
+                        mtr: true,
                         moveObject: true
                     });
 
@@ -2562,6 +2630,7 @@ const mll = (function () {
                 items: contextMenu
             });
 
+            const dblClickOptions = [];
             const accordionItems = [];
             for (const itemName in contextMenu) {
                 const item = contextMenu[itemName];
@@ -2569,6 +2638,8 @@ const mll = (function () {
                     continue;
                 }
                 if (itemName === "garrison") {
+                    dblClickOptions.push("<option value='" + itemName + "'>Garrison</option>")
+
                     elements.mobileContextBody.append(
                         "<button class='btn btn-link' style='margin: 10px 0' onclick='mll.mobileMenuAdd(\"" + itemName + "\")'>" +
                         (item.icon ? "<i class='" + item.icon + "'></i>" : "") +
@@ -2580,6 +2651,8 @@ const mll = (function () {
                     const itemButtons = [];
                     for (const subItemName in item.items) {
                         const subItem = item.items[subItemName];
+
+                        dblClickOptions.push("<option value='" + subItemName + "'>" + subItem.name + "</option>")
 
                         itemButtons.push(
                             "<button class='btn btn-link' onclick='mll.mobileMenuAdd(\"" + subItemName + "\")'>" +
@@ -2610,6 +2683,7 @@ const mll = (function () {
                 accordionItems.join("") +
                 "</div>"
             );
+            $("#dbl-click-element").html(dblClickOptions.join(""))
 
             const eCanvas = document.createElement("canvas");
             controls.exportCanvas = new fabric.Canvas(eCanvas, {
@@ -2808,45 +2882,6 @@ const mll = (function () {
                 render: renderIconDrag,
                 cornerSize: 24
             });
-
-            function deleteObject(eventData, transform) {
-                const target = transform.target;
-
-                let removedElement = false;
-                let removedDrawing = false;
-                for (let i = 0; i < placed.length; i++) {
-                    if (placed[i].type.id === target.type.id) {
-                        placed.splice(i, 1);
-                        removedElement = true;
-                        break;
-                    }
-                }
-                for (let i = 0; i < drawings.length; i++) {
-                    if (drawings[i].type.id === target.type.id) {
-                        drawings.splice(i, 1);
-                        removedDrawing = true;
-                        break;
-                    }
-                }
-
-                controls.fabricCanvas.remove(target);
-                controls.exportCanvas.remove(target);
-                if (target.type && target.type.also) {
-                    const also = target.type.also;
-                    for (let j = 0; j < also.length; j++) {
-                        controls.fabricCanvas.remove(also[j]);
-                        controls.exportCanvas.remove(also[j]);
-                    }
-                }
-                controls.fabricCanvas.requestRenderAll();
-
-                if (removedElement) {
-                    roomEditorUpdateElements();
-                }
-                if (removedDrawing) {
-                    roomEditorUpdateDrawings();
-                }
-            }
 
             function renderIcon(ctx, left, top, styleOverride, fabricObject) {
                 const size = this.cornerSize;
@@ -3082,7 +3117,11 @@ const mll = (function () {
                     return;
                 }
 
-                addMapElement(e, 'garry', null, true);
+                const dblClickType = $("#dbl-click-element").val();
+                console.log("Double Click: " + dblClickType);
+
+                contextMenuEvent = e; // not from a context menu but reuse for click position
+                mll.mobileMenuAdd(dblClickType);
             });
 
             controls.btnRemoveAllElements.on('click', function () {
@@ -3104,6 +3143,40 @@ const mll = (function () {
                 roomEditorUpdateElements()
             });
 
+            const draggingTool = $("#tool-drag"),
+                drawingTool = $("#tool-draw"),
+                eraserTool = $("#tool-erase");
+
+            function setToolSelected(type) {
+                $(".tool").removeClass("selected");
+                $("#tool-" + type).addClass("selected");
+
+                controls.fabricCanvas.isDragMode = false;
+                controls.fabricCanvas.isEraserMode = false;
+                controls.fabricCanvas.isDrawingMode = false;
+                $("canvas").removeClass("draw-mode").removeClass('drag-mode').removeClass('eraser-mode');
+                if (type === "drag") {
+                    $("canvas").addClass("drag-mode");
+                    controls.fabricCanvas.isDragMode = true;
+                } else if (type === "draw") {
+                    $("canvas").addClass("draw-mode");
+                    controls.fabricCanvas.isDrawingMode = true;
+                } else if (type === "erase") {
+                    $("canvas").addClass("eraser-mode");
+                    controls.fabricCanvas.isEraserMode = true;
+                }
+            }
+
+            draggingTool.click(function () {
+                setToolSelected('drag');
+            })
+            drawingTool.click(function () {
+                setToolSelected('draw');
+            })
+            eraserTool.click(function () {
+                setToolSelected('erase');
+            })
+
             const drawingModeEl = $('#drawing-mode'),
                 drawingStyle = $("#drawing-style"),
                 drawingColorEl = $('#drawing-color'),
@@ -3112,13 +3185,15 @@ const mll = (function () {
                 undoEl = $("#undo-path");
 
             drawingModeEl.on('click', function () {
+                controls.fabricCanvas.isDragMode = false;
+                controls.fabricCanvas.isEraserMode = false;
                 controls.fabricCanvas.isDrawingMode = !controls.fabricCanvas.isDrawingMode;
                 if (controls.fabricCanvas.isDrawingMode) {
+                    setToolSelected('draw');
                     drawingModeEl.text('Stop drawing mode');
-                    $("canvas").addClass("draw-mode").removeClass('drag-mode');
                 } else {
+                    setToolSelected('drag');
                     drawingModeEl.text('Start drawing mode');
-                    $("canvas").removeClass("draw-mode").addClass('drag-mode');
                 }
             });
 
@@ -3214,6 +3289,26 @@ const mll = (function () {
                     console.log("Shift+D")
                     drawingModeEl.click();
                 }
+                if (e.shiftKey && String.fromCharCode(e.which).toLowerCase() === 'e') {
+                    if (roomsMode && roomsRole === 'viewer') {
+                        return;
+                    }
+
+                    console.log("Shift+E");
+                    if (controls.fabricCanvas.isEraserMode) {
+                        draggingTool.click();
+                    } else {
+                        eraserTool.click();
+                    }
+                }
+                if (e.shiftKey && String.fromCharCode(e.which).toLowerCase() === 'w') {
+                    if (roomsMode && roomsRole === 'viewer') {
+                        return;
+                    }
+
+                    console.log("Shift+W");
+                    draggingTool.click();
+                }
             })
             $(document).on('keyup', function (e) {
                 if (roomsMode && roomsRole === 'viewer') {
@@ -3271,10 +3366,15 @@ const mll = (function () {
                 roomEditorUpdateControls("btnDisableAll");
             });
 
+            let erasing = false;
             let panning = false;
             controls.fabricCanvas.on('mouse:up', function (e) {
                 if (e.e.touches) {
                     return;
+                }
+                if (controls.fabricCanvas.isEraserMode === true) {
+                    controls.fabricCanvas.discardActiveObject().renderAll();
+                    erasing = false;
                 }
                 panning = false;
             });
@@ -3284,6 +3384,15 @@ const mll = (function () {
                     return;
                 }
                 console.log(e);
+                if (controls.fabricCanvas.isEraserMode === true) {
+                    erasing = true;
+                    if (e.target && e.target.type && e.target.type.id) {
+                        console.log("Erasing object " + e.target.type.id);
+                        deleteObject(e, e);
+                        controls.fabricCanvas.discardActiveObject().renderAll();
+                    }
+                    return;
+                }
                 if (e.button === 3) {
                     if (roomsMode && roomsRole === 'viewer') {
                         return;
@@ -3294,7 +3403,7 @@ const mll = (function () {
                     panning = false;
                 } else if (e.target && e.target.selectable === true && e.target.lockMovementX === false ||
                     e.transform && (e.transform.action === 'rotate' || e.transform.action.indexOf('scale') !== -1) ||
-                    controls.fabricCanvas.isDrawingMode === true) {
+                    controls.fabricCanvas.isDragMode !== true) {
                     // Dragging element
                     panning = false;
                 } else {
@@ -3304,6 +3413,13 @@ const mll = (function () {
             controls.fabricCanvas.on('mouse:move', function (e) {
                 if (e.e.touches) {
                     return;
+                }
+                if (controls.fabricCanvas.isEraserMode === true && erasing) {
+                    if (e.target && e.target.type && e.target.type.id) {
+                        console.log("Erasing object " + e.target.type.id);
+                        deleteObject(e, e);
+                        controls.fabricCanvas.discardActiveObject().renderAll();
+                    }
                 }
                 if (panning && e && e.e && (e.e.movementX || e.e.movementY)) {
                     const delta = new fabric.Point(e.e.movementX, e.e.movementY);
@@ -3323,8 +3439,7 @@ const mll = (function () {
                             // console.log(e);
                             pausePanning = true;
 
-                            controls.fabricCanvas.discardActiveObject(controls.fabricCanvas.getObjects())
-                                .requestRenderAll();
+                            controls.fabricCanvas.discardActiveObject().renderAll();
 
                             const touch1 = e.e.touches[0];
                             const touch2 = e.e.touches[1];
@@ -3365,7 +3480,7 @@ const mll = (function () {
                     }
                     if (e.target && e.target.selectable === true && e.target.lockMovementX === false ||
                         e.transform && (e.transform.action === 'rotate' || e.transform.action.indexOf('scale') !== -1) ||
-                        controls.fabricCanvas.isDrawingMode === true) {
+                        controls.fabricCanvas.isDragMode !== true) {
                         return;
                     }
                     if (pausePanning !== true && e.self.x && e.self.y) {
@@ -3743,10 +3858,7 @@ const mll = (function () {
                 console.log(event);
 
                 let file = event.target.files[0];
-
-                if (file) {
-                    //controls.inputValue.val(file.name);
-                } else {
+                if (!file) {
                     return;
                 }
 
@@ -3890,13 +4002,13 @@ const mll = (function () {
                 }
 
                 updateConfigsSelect();
-                loadFromRoomState(slides[0]);
+                loadFromRoomState(slides[0]).then(function () {
+                    console.log('???')
+                    updateZoomScale();
+                    changeZIndexBySize();
+                    fixElementSelectBoxes();
+                });
                 roomEditorUpdateSlides('import');
-                // loadFromRoomState(slides[0], function () {
-                //     roomEditorUpdateControls("importFile")
-                //     roomEditorUpdateElements();
-                //     roomEditorUpdateDrawings();
-                // });
             });
 
             internal.pageReady();

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,9 @@ canvas.drag-mode {
 canvas.draw-mode {
     cursor: crosshair !important;
 }
+canvas.eraser-mode {
+    cursor: crosshair !important;
+}
 canvas.polygon-mode {
     cursor: crosshair !important;
 }


### PR DESCRIPTION
- Add new bar above the map
    - Quick tool select: Drag, Draw, and Erase
    - New option to select the Double-Click quick element type. Double Click has been set to just garrisons from the start, now it can be configured.
    - Moved drawing and element Clear and Undo/Remove last buttons to the bar and are now labeled with words to be more clear
- Tweak import file chooser to filter by zip
- Tweak default new shape opacity again, from `0.35` to `0.5`